### PR TITLE
Add dripstone brick crafting recipes; update ES translations

### DIFF
--- a/src/main/java/org/nguh/nguhcraft/data/NguhcraftRecipeGenerator.kt
+++ b/src/main/java/org/nguh/nguhcraft/data/NguhcraftRecipeGenerator.kt
@@ -163,6 +163,12 @@ class NguhcraftRecipeGenerator(
             cinput('#', NguhBlocks.PYRITE)
         }
 
+        offerShaped(NguhBlocks.DRIPSTONE_BRICKS, 4) {
+            pattern("##")
+            pattern("##")
+            cinput('#', Items.DRIPSTONE_BLOCK)
+        }
+
         offerChainAndLantern(NguhBlocks.OCHRE_CHAIN, NguhBlocks.OCHRE_LANTERN, Items.RESIN_CLUMP, Items.OCHRE_FROGLIGHT)
         offerChainAndLantern(NguhBlocks.PEARLESCENT_CHAIN, NguhBlocks.PEARLESCENT_LANTERN, Items.AMETHYST_SHARD, Items.PEARLESCENT_FROGLIGHT)
         offerChainAndLantern(NguhBlocks.VERDANT_CHAIN, NguhBlocks.VERDANT_LANTERN, Items.EMERALD, Items.VERDANT_FROGLIGHT)
@@ -346,6 +352,7 @@ class NguhcraftRecipeGenerator(
         offerStonecuttingFamily(NguhBlocks.POLISHED_CALCITE_FAMILY, Blocks.CALCITE)
         offerStonecuttingFamily(NguhBlocks.CALCITE_BRICK_FAMILY, Blocks.CALCITE)
         offerStonecuttingRecipe(Out = NguhBlocks.PYRITE_BRICKS, In = NguhBlocks.PYRITE)
+        offerStonecuttingRecipe(Out = NguhBlocks.DRIPSTONE_BRICKS, In = Blocks.DRIPSTONE_BLOCK)
 
         for (V in NguhBlockModels.VERTICAL_SLABS)
             offerStonecuttingRecipe(Out = V.VerticalSlab, In = V.Base, 2)

--- a/src/main/resources/assets/nguhcraft/lang/es_ar.json
+++ b/src/main/resources/assets/nguhcraft/lang/es_ar.json
@@ -201,6 +201,8 @@
 	"item.nguhcraft.key_chain": "Llavero",
 	"item.nguhcraft.master_key": "Llave maestra",
 	"item.nguhcraft.music_disc_nguhrovision_2024": "Disco de música",
+	"item.nguhcraft.slab_shavings_1": "Trocito de losa",
+	"item.nguhcraft.slab_shavings_8": "8 trocitos de losa",
 	"item.nguhcraft.slablet_1": "1 losita",
 	"item.nguhcraft.slablet_2": "2 lositas",
 	"item.nguhcraft.slablet_4": "4 lositas",

--- a/src/main/resources/assets/nguhcraft/lang/es_cl.json
+++ b/src/main/resources/assets/nguhcraft/lang/es_cl.json
@@ -201,6 +201,8 @@
 	"item.nguhcraft.key_chain": "Llavero",
 	"item.nguhcraft.master_key": "Llave maestra",
 	"item.nguhcraft.music_disc_nguhrovision_2024": "Disco de música",
+	"item.nguhcraft.slab_shavings_1": "Trocito de losa",
+	"item.nguhcraft.slab_shavings_8": "8 trocitos de losa",
 	"item.nguhcraft.slablet_1": "1 losita",
 	"item.nguhcraft.slablet_2": "2 lositas",
 	"item.nguhcraft.slablet_4": "4 lositas",

--- a/src/main/resources/assets/nguhcraft/lang/es_ec.json
+++ b/src/main/resources/assets/nguhcraft/lang/es_ec.json
@@ -201,6 +201,8 @@
 	"item.nguhcraft.key_chain": "Llavero",
 	"item.nguhcraft.master_key": "Llave maestra",
 	"item.nguhcraft.music_disc_nguhrovision_2024": "Disco de música",
+	"item.nguhcraft.slab_shavings_1": "Trocito de losa",
+	"item.nguhcraft.slab_shavings_8": "8 trocitos de losa",
 	"item.nguhcraft.slablet_1": "1 losita",
 	"item.nguhcraft.slablet_2": "2 lositas",
 	"item.nguhcraft.slablet_4": "4 lositas",

--- a/src/main/resources/assets/nguhcraft/lang/es_es.json
+++ b/src/main/resources/assets/nguhcraft/lang/es_es.json
@@ -201,6 +201,8 @@
 	"item.nguhcraft.key_chain": "Llavero",
 	"item.nguhcraft.master_key": "Llave maestra",
 	"item.nguhcraft.music_disc_nguhrovision_2024": "Disco de música",
+	"item.nguhcraft.slab_shavings_1": "Trocito de losa",
+	"item.nguhcraft.slab_shavings_8": "8 trocitos de losa",
 	"item.nguhcraft.slablet_1": "1 losita",
 	"item.nguhcraft.slablet_2": "2 lositas",
 	"item.nguhcraft.slablet_4": "4 lositas",

--- a/src/main/resources/assets/nguhcraft/lang/es_mx.json
+++ b/src/main/resources/assets/nguhcraft/lang/es_mx.json
@@ -201,6 +201,8 @@
 	"item.nguhcraft.key_chain": "Llavero",
 	"item.nguhcraft.master_key": "Llave maestra",
 	"item.nguhcraft.music_disc_nguhrovision_2024": "Disco de música",
+	"item.nguhcraft.slab_shavings_1": "Trocito de losa",
+	"item.nguhcraft.slab_shavings_8": "8 trocitos de losa",
 	"item.nguhcraft.slablet_1": "1 losita",
 	"item.nguhcraft.slablet_2": "2 lositas",
 	"item.nguhcraft.slablet_4": "4 lositas",

--- a/src/main/resources/assets/nguhcraft/lang/es_uy.json
+++ b/src/main/resources/assets/nguhcraft/lang/es_uy.json
@@ -201,6 +201,8 @@
 	"item.nguhcraft.key_chain": "Llavero",
 	"item.nguhcraft.master_key": "Llave maestra",
 	"item.nguhcraft.music_disc_nguhrovision_2024": "Disco de música",
+	"item.nguhcraft.slab_shavings_1": "Trocito de losa",
+	"item.nguhcraft.slab_shavings_8": "8 trocitos de losa",
 	"item.nguhcraft.slablet_1": "1 losita",
 	"item.nguhcraft.slablet_2": "2 lositas",
 	"item.nguhcraft.slablet_4": "4 lositas",

--- a/src/main/resources/assets/nguhcraft/lang/es_ve.json
+++ b/src/main/resources/assets/nguhcraft/lang/es_ve.json
@@ -201,6 +201,8 @@
 	"item.nguhcraft.key_chain": "Llavero",
 	"item.nguhcraft.master_key": "Llave maestra",
 	"item.nguhcraft.music_disc_nguhrovision_2024": "Disco de música",
+	"item.nguhcraft.slab_shavings_1": "Trocito de losa",
+	"item.nguhcraft.slab_shavings_8": "8 trocitos de losa",
 	"item.nguhcraft.slablet_1": "1 losita",
 	"item.nguhcraft.slablet_2": "2 lositas",
 	"item.nguhcraft.slablet_4": "4 lositas",


### PR DESCRIPTION
I forgot to make dripstone bricks craftable - I made all of the blocktype recipes work, just not that one. Whoops.