### PR TITLE
Fix crash at startup due to invalid json

### DIFF
--- a/src/main/resources/assets/nguhcraft/emoji/nguhflags.json
+++ b/src/main/resources/assets/nguhcraft/emoji/nguhflags.json
@@ -79,7 +79,7 @@
 	"flag_vdc": "\udb86\uddcd",
 	"flag_wan": "\udb86\uddce",
 	"flag_wsk": "\udb86\uddcf",
-	"flag_ykm": "\udb86\uddd0",
+	"flag_vib": "\udb86\uddd0",
 	"flag_yys": "\udb86\uddd1",
 	"flag_hed": "\udb86\uddd2",
 	"flag_kil": "\udb86\uddd3",


### PR DESCRIPTION
The most recent commit that added some flags added a duplicate entry to nguhflags.json, causing a crash on startup. The duplicates' key has been renamed to flag_vib, as recommended here https://discord.com/channels/697450809390268467/1351256799147458620/1503456540785508573